### PR TITLE
[WO-380] escaped quotes werent parsed properly

### DIFF
--- a/src/imap-parser.js
+++ b/src/imap-parser.js
@@ -442,6 +442,7 @@
                         if (i >= len) {
                             throw new Error("Unexpected end of input at position " + (this.pos + i));
                         }
+                        chr = this.str.charAt(i);
                     }
 
                     if (imapFormalSyntax["TEXT-CHAR"]().indexOf(chr) < 0) {

--- a/test/imap-parser-unit.js
+++ b/test/imap-parser-unit.js
@@ -454,6 +454,25 @@
                 }).to.throw(Error);
             });
         });
+
+        describe("Escaped quotes", function() {
+            it('should succeed', function() {
+                expect(imapHandler.parser('* 331 FETCH (ENVELOPE ("=?ISO-8859-1?Q?\\"G=FCnter__Hammerl\\"?="))').attributes).to.deep.equal([{
+                        type: "ATOM",
+                        value: "FETCH"
+                    },
+                    [{
+                            type: "ATOM",
+                            value: "ENVELOPE"
+                        },
+                        [{
+                            type: "STRING",
+                            value: "=?ISO-8859-1?Q?\"G=FCnter__Hammerl\"?="
+                        }]
+                    ]
+                ]);
+            });
+        });
     });
 
 }));


### PR DESCRIPTION
Gmail decodes doublequotes in mime encoded words when returning envelope data from IMAP

Actual header:

```
=?UTF-8?Q?=22G=C3=BCnter__Hammerl=22?=
```

Gmail Envelope header in IMAP response:

```
"=?ISO-8859-1?Q?\"G=FCnter__Hammerl\"?="
```

imap-handler failed to process escaped characters properly. Instead of returning the escaped char, backslash escape was returned instead

```
 "=?ISO-8859-1?Q?\\G=FCnter__Hammerl\\?="
```

which then resulted after decoding into

```
"\\Günter  Hammerl\\"
```
