### PR TITLE
UTF-8 encode Unicode characters in strings and literals.

### DIFF
--- a/src/imap-compiler.js
+++ b/src/imap-compiler.js
@@ -32,6 +32,22 @@
 
     "use strict";
 
+    var utf8Encode = function(chars) {
+        var ascii = "";
+        for(var i = 0; i < chars.length; i++) {
+            var c = chars[i].charCodeAt(0);
+            if (c <= 0x7f) {
+                ascii += chars[i];
+            } else {
+                var h = encodeURIComponent(chars[i]).substr(1).split('%');
+                for (var j = 0; j < h.length; j++) {
+                    ascii += String.fromCharCode(parseInt(h[j], 16));
+                }
+            }
+        }
+        return ascii;
+    };
+
     /**
      * Compiles an input object into
      */
@@ -71,17 +87,19 @@
                 lastType = node.type;
                 switch (node.type.toUpperCase()) {
                     case "LITERAL":
+                        var s = "";
                         if (!node.value) {
                             resp += "{0}\r\n";
                         } else {
-                            resp += "{" + node.value.length + "}\r\n";
+                            s = utf8Encode(node.value);
+                            resp += "{" + s.length + "}\r\n";
                         }
                         respParts.push(resp);
-                        resp = node.value || "";
+                        resp = s;
                         break;
 
                     case "STRING":
-                        resp += JSON.stringify(node.value || "");
+                        resp += JSON.stringify(utf8Encode(node.value) || "");
                         break;
 
                     case "TEXT":

--- a/test/imap-compiler-unit.js
+++ b/test/imap-compiler-unit.js
@@ -191,6 +191,19 @@
                     };
                     expect(imapHandler.compiler(parsed, true)).to.deep.equal(["{10}\r\n", "Tere tere! {9}\r\n", "Vana kere"]);
                 });
+
+                it('should UTF-8 encode literals containing Unicode characters', function() {
+                    var parsed = {
+                        attributes: [{
+                            type: "LITERAL",
+                            value: "Jyväskylä"
+                        }, {
+                            type: "LITERAL",
+                            value: "€"
+                        }]
+                    };
+                    expect(imapHandler.compiler(parsed, true)).to.deep.equal(["{11}\r\n", "JyvÃ¤skylÃ¤ {3}\r\n", "\xe2\x82\xac"]);
+                });
             });
         });
     });


### PR DESCRIPTION
This fixes non-ASCII search queries in browserbox. Perhaps this breaks the abstraction and should be dealt with in browserbox but you can be the judge of that. If that's the case then there should at least be some assertion code in imap-handler that checks for valid input.
