### PR TITLE
[WO-782] Added option to compile commands for a log

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ Where
 
   * **commandObject** is an object parsed with `imapHandler.parser()` or self generated
   * **asArray** if set to `true` return the value as an array instead of a string where the command is split on LITERAL notions
+  * **isLogging** if set to true, do not include literals and long strings, useful when logging stuff and do not want to include message bodies etc. Additionally nodes with `sensitive: true` options are also not displayed (useful with logging passwords) if `logging` is used.
 
 The function returns a string or if `asArray` is set to true, as an array which is split on LITERAL notions, eg. "{4}\r\nabcde" becomes ["{4}\r\n", "abcde"]. This is useful if you need to wait for "+" response from the server before you can transmit the literal data.
 

--- a/src/imap-parser.js
+++ b/src/imap-parser.js
@@ -468,9 +468,11 @@
                         chr = this.str.charAt(i);
                     }
 
+                    /* // skip this check, otherwise the parser might explode on binary input
                     if (imapFormalSyntax['TEXT-CHAR']().indexOf(chr) < 0) {
                         throw new Error('Unexpected char at position ' + (this.pos + i));
                     }
+                    */
 
                     this.currentNode.value += chr;
                     break;

--- a/test/imap-compiler-unit.js
+++ b/test/imap-compiler-unit.js
@@ -106,13 +106,48 @@
                 it('should compile correctly', function() {
                     parsed.attributes = [{
                             type: 'String',
-                            value: 'Tere tere!'
+                            value: 'Tere tere!',
+                            sensitive: true
                         },
                         'Vana kere'
                     ];
 
                     expect(imapHandler.compiler(parsed)).to.equal('* CMD "Tere tere!" "Vana kere"');
 
+                });
+
+                it('should keep short strings', function() {
+                    parsed.attributes = [{
+                            type: 'String',
+                            value: 'Tere tere!'
+                        },
+                        'Vana kere'
+                    ];
+
+                    expect(imapHandler.compiler(parsed, false, true)).to.equal('* CMD "Tere tere!" "Vana kere"');
+                });
+
+                it('should hide strings', function() {
+                    parsed.attributes = [{
+                            type: 'String',
+                            value: 'Tere tere!',
+                            sensitive: true
+                        },
+                        'Vana kere'
+                    ];
+
+                    expect(imapHandler.compiler(parsed, false, true)).to.equal('* CMD "(* value hidden *)" "Vana kere"');
+                });
+
+                it('should hide long strings', function() {
+                    parsed.attributes = [{
+                            type: 'String',
+                            value: 'Tere tere! Tere tere! Tere tere! Tere tere! Tere tere!'
+                        },
+                        'Vana kere'
+                    ];
+
+                    expect(imapHandler.compiler(parsed, false, true)).to.equal('* CMD "(* 54B string *)" "Vana kere"');
                 });
             });
 
@@ -190,6 +225,21 @@
                         }]
                     };
                     expect(imapHandler.compiler(parsed, true)).to.deep.equal(['{10}\r\n', 'Tere tere! {9}\r\n', 'Vana kere']);
+                });
+
+                it('shoud return byte length', function() {
+                    var parsed = {
+                        tag: '*',
+                        command: 'CMD',
+                        attributes: [{
+                                type: 'LITERAL',
+                                value: 'Tere tere!'
+                            },
+                            'Vana kere'
+                        ]
+                    };
+
+                    expect(imapHandler.compiler(parsed, false, true)).to.equal('* CMD "(* 10B literal *)" "Vana kere"');
                 });
             });
         });

--- a/test/imap-parser-unit.js
+++ b/test/imap-parser-unit.js
@@ -176,6 +176,22 @@
                     value: 'DEFGH'
                 }]);
             });
+
+            it('should not explode on invalid char', function() {
+                expect(imapHandler.parser('* 1 FETCH (BODY[] "\xc2")').attributes).to.deep.equal([{
+                        type: 'ATOM',
+                        value: 'FETCH'
+                    },
+                    [{
+                        type: 'ATOM',
+                        value: 'BODY',
+                        section: []
+                    }, {
+                        type: 'STRING',
+                        value: '\xc2'
+                    }]
+                ]);
+            });
         });
 
         describe('get list', function() {


### PR DESCRIPTION
Long strings, literal values and data marked as sensitive is skipped when compiling commands with the `isLogging` argument