### PR TITLE
Remove erroneous range check for partial fetches.

### DIFF
--- a/src/imap-parser.js
+++ b/src/imap-parser.js
@@ -184,9 +184,6 @@
                     break;
                 case 'PARTIAL':
                     partial = node.value.split('.').map(Number);
-                    if (partial.slice(-1)[0] < partial.slice(0, 1)[0]) {
-                        throw new Error('Invalid partial value at position ' + node.startPos);
-                    }
                     branch[branch.length - 1].partial = partial;
                     break;
             }

--- a/test/imap-parser-unit.js
+++ b/test/imap-parser-unit.js
@@ -659,10 +659,6 @@
                 }).to.throw(Error);
 
                 expect(function() {
-                    imapHandler.parser('TAG1 CMD BODY[]<123.0>');
-                }).to.throw(Error);
-
-                expect(function() {
                     imapHandler.parser('TAG1 CMD BODY[]<01>');
                 }).to.throw(Error);
 


### PR DESCRIPTION
Per <https://tools.ietf.org/html/rfc3501#section-6.4.5>, IMAP partial fetches take the form `<start.count>`. This range check appears to have been added under the understandable but incorrect assumption that the form was `<start.end>`, so we don't need the comparison here.